### PR TITLE
fix (namespace) adding misisng namespace identifier on SimpleXMLElement

### DIFF
--- a/src/Plugin/WSDecoder/WSDecoderXML.php
+++ b/src/Plugin/WSDecoder/WSDecoderXML.php
@@ -26,7 +26,7 @@ class WSDecoderXML extends WSDecoderBase {
     $data = trim($data);
     libxml_use_internal_errors(TRUE);
     try {
-      $data = new SimpleXMLElement($data);
+      $data = new \SimpleXMLElement($data);
       if ($data->count() == 0) {
         return [$data->getName() => $data->__toString()];
       }


### PR DESCRIPTION
This fixes an error that occurs when using XML Decoder:

> PHP Fatal error:  Class 'Drupal\\wsdata\\Plugin\\WSDecoder\\SimpleXMLElement' not found in /var/www/html/drupal/modules/wsdata/src/Plugin/WSDecoder/WSDecoderXML.php on line 29